### PR TITLE
fix error index of array items, close vuejs/vue-devtools#316

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function encode (data, replacer, list, seen) {
       }
       stored[i] = encode(value, replacer, list, seen)
     }
-    seen.set(data, list.length)
   } else {
     index = list.length
     list.push(data)

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ describe('circular-json', function () {
   o.c.f = o.d
   o.b = o.c
   o.arr = [o.a, o.c, o.d]
+  o.d.arr = o.arr
 
   o = c.parse(c.stringify(o))
 
@@ -33,6 +34,7 @@ describe('circular-json', function () {
   it('nested cross reference', function () {
     assert.ok(o.c.f === o.d)
     assert.ok(o.b = o.c)
+    assert.ok(o.arr === o.d.arr)
   })
 
   it('array reference', function () {


### PR DESCRIPTION
Found a bug in vue-devtools(vuejs/vue-devtools#316), finally point out this package cause the bug.

Details:
index of array is set 2 times, the second time is a mistake. So if there are several keys reference to same array, keys except the first one will get a wrong index.