### PR TITLE
Removed redundant line of code

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ function encode (data, replacer, list, seen) {
       stored[i] = encode(value, replacer, list, seen)
     }
   } else {
-    index = list.length
     list.push(data)
   }
   return index


### PR DESCRIPTION
`index` is already set to the correct value at `var index = list.length`, line 7.